### PR TITLE
Update BigInt.json

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -18,7 +18,7 @@
               "version_added": null
             },
             "firefox": {
-              "version_added": "65",
+              "version_added": "67",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Firefox may have the javascript.options.bigint flag since version 65, but BigInt doesn’t work in versions 65 and 66.
Test: https://bittersmann.de/test/2019fact.html

A checklist to help your pull request get merged faster:
- [ ] Summarize your changes
- [ ] Data: link to resources that verify support information (such as browser's docs, changelogs, source control, bug trackers, and tests)
- [ ] Data: if you tested something, describe how you tested with details like browser and version
- [ ] Review the results of the linter and fix problems reported (If you need help, please ask in a comment!)
- [ ] Link to related issues or pull requests, if any
